### PR TITLE
functionality to get available layouts from custom layouts server

### DIFF
--- a/app/src/main/java/me/guillaumin/android/osmtracker/activity/AvailableLayouts.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/activity/AvailableLayouts.java
@@ -12,25 +12,47 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import org.json.JSONArray;
+
+import java.util.List;
+
 import me.guillaumin.android.osmtracker.R;
+import me.guillaumin.android.osmtracker.layout.ListAvailableCustomLayoutsTask;
+import me.guillaumin.android.osmtracker.util.CustomLayoutsUtils;
 
 /**
  * Created by emmanuel on 10/11/17.
  */
 
 public class AvailableLayouts extends Activity {
+
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setTitle("Available Layouts");
         setContentView(R.layout.available_layouts);
+
+        // call task to downloand and parse the response to get the list of
+        // available layouts
+        new ListAvailableCustomLayoutsTask(){
+            protected void onPostExecute(List<String> options){
+                setAvailableLayouts(options);
+            }
+
+        }.execute();
+
+
+    }
+
+
+    public void setAvailableLayouts(List<String> options) {
         LinearLayout ly = (LinearLayout)findViewById(R.id.root_layout);
-        String[] options = {"Hydrants","Public Transport","Accesibility"};
         int AT_START = 0; //the position to insert the view at
         for(String option : options){
             TextView c = new TextView(this);
             c.setHeight(200);
-            c.setText(option +"(hold me)");
+            c.setText(CustomLayoutsUtils.convertFileName(option, false));
             c.setTextSize((float)30);
             registerForContextMenu(c);
             c.setOnLongClickListener(new View.OnLongClickListener() {
@@ -44,6 +66,7 @@ public class AvailableLayouts extends Activity {
             ly.addView(c,AT_START);
         }
     }
+
 
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {

--- a/app/src/main/java/me/guillaumin/android/osmtracker/layout/ListAvailableCustomLayoutsTask.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/layout/ListAvailableCustomLayoutsTask.java
@@ -1,0 +1,110 @@
+package me.guillaumin.android.osmtracker.layout;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by james on 07/12/17.
+ */
+
+public class ListAvailableCustomLayoutsTask extends AsyncTask<Void, Integer, List<String>> {
+    private static final String TAG = "List Custom Layouts";
+
+    @Override
+    protected List<String> doInBackground(Void... voids) {
+        // https://crunchify.com/in-java-how-to-read-github-file-contents-using-httpurlconnection-convert-stream-to-string-utility/
+
+        //TODO: get default server_URL (without metadata folder in it)
+        String server_url = "https://api.github.com/repos/LabExperimental-SIUA/osmtracker-android/contents/layouts/metadata?ref=layouts";
+
+        try {
+            //URL url = new URL(urlString[0]);
+            URL url = new URL(server_url);
+            // Open Url Connection
+            HttpURLConnection httpConnection = (HttpURLConnection) url.openConnection();
+            InputStream stream = httpConnection.getInputStream();
+            String response = getStringFromStream(stream);
+
+            Log.i(TAG, response);
+
+            List<String> options = parseResponse(response);
+            return options;
+
+        } catch (Exception e) {
+            Log.e(TAG, "Error. Exception: " + e.toString());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    // ConvertStreamToString() Utility
+    private String getStringFromStream(InputStream stream) throws IOException {
+        if (stream != null) {
+            Writer writer = new StringWriter();
+
+            char[] buffer = new char[2048];
+            try {
+                Reader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+                int counter;
+                while ((counter = reader.read(buffer)) != -1) {
+                    writer.write(buffer, 0, counter);
+                }
+            } finally {
+                stream.close();
+            }
+            return writer.toString();
+        } else {
+            // return "No Contents";
+            throw new  IOException();
+        }
+    }
+
+
+    private List<String> parseResponse(String response) {
+        /*
+        parse the string (representation of a json) to get only the values associated with
+        key "name", which are the file names of the folder requested before.
+         */
+
+        List<String> options = new ArrayList<String>();
+
+
+        try {
+            // create JSON Object
+            JSONArray jsonArray = new JSONArray(response);
+
+            for (int i= 0; i < jsonArray.length(); i++) {
+                // create json object for every element of the array
+                JSONObject object = jsonArray.getJSONObject(i);
+                // get the value associated with
+                options.add( object.getString("name") );
+            }
+
+
+        } catch (JSONException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+            return null;
+        }
+
+        return options;
+    }
+
+
+}


### PR DESCRIPTION
Incorpora la funcionalidad para consultar el repositorio del labexp y obtener los "layouts" disponibles. En este PR está integrado con la actividad `AvailableLayouts` (con un muy pequeño cambio). 

Por hacer:
- [x] manejo de errores (en GUI y App)
- [x] mostrar nombre de layout bien. 
- [x] utilizar la dirección del servidor guardada en `preferences`

Nota: Este PR cerraría el issue #65 